### PR TITLE
Revert to previous release plugin version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,17 +1,19 @@
+import pl.allegro.tech.build.axion.release.ReleaseTask
+
 plugins {
     id("com.vantiq.gradle-dcompose-plugin") version "0.17.2"
     id("com.gradle.plugin-publish") version "1.3.0"
-    id("pl.allegro.tech.build.axion-release") version "1.14.4"
+    id("pl.allegro.tech.build.axion-release") version "1.13.14"
 }
 apply plugin: 'groovy'
 apply plugin: 'idea'
 apply plugin: 'eclipse'
 
 group 'com.vantiq'
-version = project.findProperty('publishVersion') ?: scmVersion.version
 scmVersion {
     versionIncrementer 'incrementMinor'
 }
+version = project.findProperty('publishVersion') ?: scmVersion.version
 
 repositories {
     mavenCentral()
@@ -78,6 +80,14 @@ private Map getDockerConfig() {
             dockerPort: dcompose.dockerDaemon.findHostPort(findHostProps, 2375),
             networkTestPort: dcompose.dockerDaemon.findHostPort(findHostProps, 1500)
     ]
+}
+
+tasks.register('patchRelease', ReleaseTask) {
+    doFirst {
+        scmVersion {
+            versionIncrementer 'incrementPatch'
+        }
+    }
 }
 
 tasks.register('setupTest') {


### PR DESCRIPTION
This is to avoid an issue with Gradle 8.x on Windows when using the 1.14.x version of the plugin (later versions don't have that issue, but they also require Java 11).